### PR TITLE
To keep the compatible with mobile version when we use image as icon

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ specifiers:
   tinycolor2: ^1.4.2
   typescript: ^4.8.4
   vite: 3.1.8
+  vite-plugin-logseq: ^1.1.2
 
 dependencies:
   '@logseq/libs': 0.0.10
@@ -35,6 +36,7 @@ devDependencies:
   semantic-release: 19.0.5
   typescript: 4.8.4
   vite: 3.1.8
+  vite-plugin-logseq: 1.1.2
 
 packages:
 
@@ -2403,6 +2405,13 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /magic-string/0.26.7:
+    resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
+    engines: {node: '>=12'}
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: true
+
   /make-error/1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: true
@@ -3255,6 +3264,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /sourcemap-codec/1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    dev: true
+
   /spawn-error-forwarder/1.0.0:
     resolution: {integrity: sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==}
     dev: true
@@ -3621,6 +3634,12 @@ packages:
     dependencies:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
+    dev: true
+
+  /vite-plugin-logseq/1.1.2:
+    resolution: {integrity: sha512-l5YvoH3K25Zx9eqgoJFug7NfVqSPwq7/FcYYhN1TkdG8ZOiD+c+TAwdCS2dJbGgvx8GmSpbgwSZWgslB+wH53g==}
+    dependencies:
+      magic-string: 0.26.7
     dev: true
 
   /vite/3.1.8:

--- a/src/modules/pageIcons/pageIcons.css
+++ b/src/modules/pageIcons/pageIcons.css
@@ -10,14 +10,20 @@
     line-height: 1em;
     width: 1.2em;
 }
+.awLi-icon2{
+    margin-right: 0.64em;
+}
 .title .awLi-icon {
     display: inline-block;
     width: 1.4em;
     margin-right: 0.34em;
     font-family: var(--icon-font);
     text-align: center;
-    align-self: end;
+    align-self: center;
     line-height: inherit;
+}
+.title .awLi-icon2{
+    margin-right: 0.64em;
 }
 
 /* color */

--- a/src/modules/pageIcons/pageIcons.ts
+++ b/src/modules/pageIcons/pageIcons.ts
@@ -136,15 +136,22 @@ export const processLinkItem = async (linkItem: HTMLElement) => {
 export const setStyleToLinkItem = async (linkItem: HTMLElement, pageProps: propsObject) => {
     linkItem.classList.remove('awLi-stroke');
     // icon
-    const pageIcon = pageProps['icon'];
+    const pageIcon = pageProps['icon-url'] ? `<img src="${pageProps['icon-url']}" style="width:1em">` : pageProps['icon'];
+    const pageIcon2 = pageProps['icon-url2'] ? `<img src="${pageProps['icon-url2']}" style="width:1em">` : pageProps['icon2'];
     if (pageIcon && pageIcon !== 'none') {
         const oldPageIcon = linkItem.querySelector('.awLi-icon');
+        const oldPageIcon2 = linkItem.querySelector('.awLi-icon2');
         if (oldPageIcon) {
+            if( oldPageIcon2 && oldPageIcon2.innerHTML!=pageIcon2){
+                linkItem.insertAdjacentHTML('afterbegin', `<span class="awLi-icon2 awLi-icon">${pageIcon2}</span>`);
+                oldPageIcon2.remove();
+            }
             if (oldPageIcon.innerHTML !== pageIcon) {
                 linkItem.insertAdjacentHTML('afterbegin', `<span class="awLi-icon">${pageIcon}</span>`);
                 oldPageIcon.remove();
             }
         } else {
+            if(pageIcon2) linkItem.insertAdjacentHTML('afterbegin', `<span class="awLi-icon2 awLi-icon">${pageIcon2}</span>`);
             linkItem.insertAdjacentHTML('afterbegin', `<span class="awLi-icon">${pageIcon}</span>`);
         }
     }
@@ -226,7 +233,6 @@ const setTabsCSS = () => {
                 font-family: 'Fira Code Nerd Font', 'Fira Code', 'Fira Sans';
                 text-align: center;
                 line-height: 1em;
-                width: 1.2em;
             }
             .light .awLi-stroke {
                 -webkit-text-stroke: 0.3px #00000088;

--- a/src/modules/pageIcons/queries.ts
+++ b/src/modules/pageIcons/queries.ts
@@ -3,6 +3,9 @@ import { globalContext } from '../internal';
 
 export interface propsObject {
     icon?: string;
+    "icon-url"?: string;
+    icon2?: string;
+    "icon-url2"?: string;
     color?: string;
     needStroke?: boolean;
 }
@@ -58,11 +61,23 @@ export const getPageProps = async (title: string): Promise<propsObject> => {
         pageProps = { ...journalDefaultProps, ...pageProps };
     } else {
         const queryResultArr = await logseq.DB.datascriptQuery(iconQuery);
-        if (queryResultArr[0] && queryResultArr[0][0] && queryResultArr[0][0].icon) {
-            pageProps.icon = queryResultArr[0][0].icon;
-        }
-        if (queryResultArr[0] && queryResultArr[0][0] && queryResultArr[0][0].color) {
-            pageProps.color = queryResultArr[0][0].color.replaceAll('"', '');
+        if(queryResultArr.length && queryResultArr[0].length){
+            const row = queryResultArr[0][0];
+            if (row.icon) {
+                pageProps.icon = row.icon;
+            }
+            if (row.color) {
+                pageProps.color = row.color.replaceAll('"', '');
+            }
+            if (row[".icon-url"] || row["icon-url"]) {
+                pageProps["icon-url"] = row[".icon-url"] || row["icon-url"];
+            }
+            if (row[".icon2"] || row["icon2"]) {
+                pageProps.icon2 = row[".icon2"] || row["icon2"];
+            }
+            if (row[".icon-url2"] || row["icon-url2"]) {
+                pageProps["icon-url2"] = row[".icon-url2"] || row["icon-url2"];
+            }
         }
     }
     return pageProps;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from 'vite';
+import logseqDevPlugin from "vite-plugin-logseq";
 
 const name = 'awesomeLinks';
 
 export default defineConfig({
+  plugins: [logseqDevPlugin()],
   base: '',
   build: {
     sourcemap: true,


### PR DESCRIPTION
- To keep the compatible with mobile version, add "icon-url::" page property for icon image
- add support for "icon2::" and "icon-url2::" page properties for one extra icon or icon image (only be effective when "icon::" or "icon-url::" is provided)
- add dev dependency "vite-plugin-logseq" to use logseqDevPlugin() for for 'npm run dev'
