### PR TITLE
fix(page-icons): align page icons

### DIFF
--- a/src/modules/globals.ts
+++ b/src/modules/globals.ts
@@ -23,7 +23,7 @@ export const globals: globalContextType = {
     isPluginEnabled: 'is-awLi-enabled',
     extLinksSelector: '.external-link',
     pageLinksSelector: '.page-ref:not(.page-property-key), .tag, .references li a',
-    titleSelector: '.page-title, .journal-title .title',
+    titleSelector: '.page-title .title, .journal-title .title',
     sidebarLinkSelector: '.nav-contents-container .page-title',
     tabLinkSelector: '.logseq-tab:not(.close-all) .logseq-tab-title',
     tagHasBg: false,
@@ -33,4 +33,3 @@ export const globals: globalContextType = {
     defaultPageProps: Object.create(null),
     defaultJournalProps: Object.create(null),
 };
-


### PR DESCRIPTION
The selector for `titles` in `page view` has been changed in a similar way to the selector for `titles` in `journal view`

![Untitled-2023-10-12-0503-crop](https://github.com/yoyurec/logseq-awesome-links/assets/50716292/803af4ac-c894-49d8-866e-4be0099c0108)

Tested with 0.9.19 version of Logseq

