### PR TITLE
fix: Add props to alias query

### DIFF
--- a/src/modules/pageIcons/queries.ts
+++ b/src/modules/pageIcons/queries.ts
@@ -96,6 +96,7 @@ export const getAliasedPageTitle = async (title: string): Promise<string> => {
         :where
             [?id :block/name "${title}"]
             [?origid :block/alias ?id]
+            [?origid :block/properties ?props]
             [?origid :block/name ?origtitle]
     ]
     `;


### PR DESCRIPTION
May fix #11 

There is an edge case where the page that aliases point to was created _after_ the page with the name of the alias, giving the alias pointer page a lower number and therefore selected first in queries.

An easy way (but not foolproof) way to reproduce this problem would be to create a page in the plural (e.g. `[[people]]`), then decide to make a singular page as the main page (e.g. `[[person]]` with `alias:: people`). Any other sort of renaming or reassigning could lead to this edge case, too.

This fix works by assuming that _only_ the page that all other aliases point to contains any properties. By querying for the mere presence of properties, we can deduce which page all the others are aliases of.

## Examples

| v1.15.16 | This PR |
| --- | --- |
| ![species card pre image](https://github.com/yoyurec/logseq-awesome-links/assets/25492070/713afa12-a216-4416-bd33-eb0bd34196ba) | ![species card post image](https://github.com/yoyurec/logseq-awesome-links/assets/25492070/50580ec0-7ad4-49d3-989e-2d884b8cb037) |
| ![cattle pre image](https://github.com/yoyurec/logseq-awesome-links/assets/25492070/681ebe38-eea0-4eb4-94e7-65e29d03ca2a) | ![cattle post image](https://github.com/yoyurec/logseq-awesome-links/assets/25492070/41a301bb-a72f-4b20-90ab-cb2354805a3c) |



