### PR TITLE
fix(favicons): cache shows wrong Google Docs icons

### DIFF
--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -30,6 +30,15 @@ export const checkUpdate = async () => {
     }
 }
 
+export const getBase64FromUrlWithCache = async (url: string): Promise<string> => {
+    if (globals.favIconsCache[url]) {
+        return globals.favIconsCache[url];
+    }
+    const favicon = await getBase64FromUrl(url);
+    globals.favIconsCache[url] = favicon;
+    return favicon;
+}
+
 // Generate Base64 from image URL
 export const getBase64FromUrl = async (url: string): Promise<string> => {
     let data;


### PR DESCRIPTION
When this plugin fetches favicon URLs, it uses a basic Map to cache the favicon response bodies in memory. Previously this Map was keyed using the hostname of the URL in the block content. However, this caused an incompatibility with hard-coded path-specific exceptions that this plugin implements for Google Docs.

So, if you have the following Logseq page:

```md
- https://docs.google.com/document/xxx
- https://docs.google.com/spreadsheets/xxx
- https://docs.google.com/presentation/xxx
```

The cache would side-step the path-specific checks, and all the links would display the same icon:
<img width="778" alt="Screenshot 2024-05-26 at 9 38 53 AM" src="https://github.com/yoyurec/logseq-awesome-links/assets/149842/e7a78f2b-59ec-429a-a046-bc448c6995de">

This change shifts the cache around just the fetch of the favicon, and uses the favicon's URL as the cache key. Note this means the cache is no longer covers the conditionals in getFaviconData, but this should be a minimal tradeoff for displaying the correct icon.

Fixes #49 