### PR TITLE
fix: inserting icon right before text node, instead of inserting as first item

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,9 @@ jobs:
           node-version: "18"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.4
+        uses: pnpm/action-setup@v4
         with:
-          version: 7
+          version: latest
 
       - name: Install dependencies
         run: pnpm install

--- a/src/modules/pageIcons/pageIcons.ts
+++ b/src/modules/pageIcons/pageIcons.ts
@@ -1,7 +1,7 @@
 import fastdom from 'fastdom'
 
 import { body, doc, globals, propsObject, root } from '../globals';
-import { settingsTextToPropsObj, isNeedLowContrastFix, isEmoji, injectPluginCSS, ejectPluginCSS } from '../utils';
+import { settingsTextToPropsObj, isNeedLowContrastFix, isEmoji, injectPluginCSS, ejectPluginCSS, htmlToElement } from '../utils';
 import { getPropsByPageName } from './queries';
 
 import pageIconsStyles from  './pageIcons.css?inline';
@@ -129,11 +129,13 @@ const setIconToLinkItem = async (linkItem: HTMLElement, pageProps: propsObject, 
         return;
     }
     if (pageIcon && pageIcon !== 'none') {
-
         const oldPageIcon = linkItem.querySelector('.awLi-icon');
         oldPageIcon && oldPageIcon.remove();
         hideTitle(linkItem, pageProps);
-        linkItem.insertAdjacentHTML('afterbegin', `<span class="awLi-icon" data-is-emoji="${isEmoji(pageIcon)}">${pageIcon}</span>`);
+
+        const iconNode = htmlToElement(`<span class="awLi-icon" data-is-emoji="${isEmoji(pageIcon)}">${pageIcon}</span>`);
+        const lastNode = linkItem.childNodes[linkItem.childNodes.length - 1];
+        linkItem.insertBefore(iconNode, lastNode);
     }
 }
 

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -108,7 +108,7 @@ export const ejectPluginCSS = (iframeId: string, label: string) => {
  * source: https://stackoverflow.com/a/35385518/7662783
  */
 export function htmlToElement(html: string): ChildNode {
-    var template = document.createElement('template');
+    const template = document.createElement('template');
     html = html.trim(); // Never return a text node of whitespace as the result
     template.innerHTML = html;
     return template.content.firstChild as ChildNode;

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -103,3 +103,13 @@ export const ejectPluginCSS = (iframeId: string, label: string) => {
     }
     pluginIframe.contentDocument?.getElementById(label)?.remove();
 }
+
+/**
+ * source: https://stackoverflow.com/a/35385518/7662783
+ */
+export function htmlToElement(html: string): ChildNode {
+    var template = document.createElement('template');
+    html = html.trim(); // Never return a text node of whitespace as the result
+    template.innerHTML = html;
+    return template.content.firstChild as ChildNode;
+}


### PR DESCRIPTION
This is to keep compatibility with other plugins or custom JS code

Re-creating [PR](https://github.com/yoyurec/logseq-awesome-links/pull/56).